### PR TITLE
fix(#59): Increases the actor timeouts

### DIFF
--- a/powerapi-core/src/main/scala/org/powerapi/PowerMeter.scala
+++ b/powerapi-core/src/main/scala/org/powerapi/PowerMeter.scala
@@ -51,7 +51,7 @@ object PowerMeterMessages {
 trait PowerMeterConfiguration extends Configuration {
   lazy val timeout: Timeout = load { _.getDuration("powerapi.actors.timeout", TimeUnit.MILLISECONDS) } match {
     case ConfigValue(value) => Timeout(value.milliseconds)
-    case _ => Timeout(1l.seconds)
+    case _ => Timeout(15l.seconds)
   }
 }
 

--- a/powerapi-core/src/main/scala/org/powerapi/module/libpfm/LibpfmCoreSensorConfiguration.scala
+++ b/powerapi-core/src/main/scala/org/powerapi/module/libpfm/LibpfmCoreSensorConfiguration.scala
@@ -39,7 +39,7 @@ import scala.concurrent.duration.DurationLong
 trait LibpfmCoreSensorConfiguration extends Configuration {
   lazy val timeout: Timeout = load { _.getDuration("powerapi.actors.timeout", TimeUnit.MILLISECONDS) } match {
     case ConfigValue(value) => Timeout(value.milliseconds)
-    case _ => Timeout(1l.seconds)
+    case _ => Timeout(15l.seconds)
   }
 
   lazy val topology: Map[Int, Set[Int]] = load { conf =>

--- a/powerapi-sampling/src/universal/conf/sampling.conf
+++ b/powerapi-sampling/src/universal/conf/sampling.conf
@@ -1,6 +1,4 @@
 # Configuration parameters to edit with your own settings.
-interval = 250ms
-
 powerspy.mac = "00:0B:CE:07:1E:9B"
 
 powerapi.cpu.topology = [
@@ -10,10 +8,6 @@ powerapi.cpu.topology = [
   { core = 3, indexes = [3, 7] }
 ]
 
-powerapi.sampling.step-duration = 5
-powerapi.sampling.sampling-directory = "samples"
-powerapi.sampling.processing-directory = "processing"
-powerapi.sampling.computing-directory = "formulae"
 powerapi.sampling.dvfs = true
 powerapi.sampling.turbo = true
 
@@ -23,7 +17,9 @@ powerapi.cycles-polynom-regression.unhalted-cycles-event = "CPU_CLK_UNHALTED:THR
 powerapi.cycles-polynom-regression.ref-cycles-event = "CPU_CLK_UNHALTED:REF_P"
 
 # You should not change these parameters
-powerapi.actors.timeout = 30s
+interval = 1s
+powerapi.actors.timeout = 15s
 powerapi.sampling.interval = ${interval}
 powerspy.interval = ${interval}
 powerapi.sampling.steps = [100, 25]
+powerapi.sampling.step-duration = 10


### PR DESCRIPTION
Closes #68.

On some limited architecture, the default actor timeout is not enough and causes some crash.