### PR TITLE
Improve containers monitoring

### DIFF
--- a/powerapi-cli/build.sbt
+++ b/powerapi-cli/build.sbt
@@ -1,5 +1,9 @@
 name := "powerapi-cli"
 
+libraryDependencies ++= Seq(
+  "com.spotify" % "docker-client" % "8.11.1"
+)
+
 mappings in Universal ++= {
   val dir = baseDirectory.value.getParentFile
 

--- a/powerapi-core/src/main/scala/org/powerapi/core/target/Target.scala
+++ b/powerapi-core/src/main/scala/org/powerapi/core/target/Target.scala
@@ -60,7 +60,7 @@ case class Application(name: String) extends Target {
   * @author <a href="mailto:l.huertas.pro@gmail.com">Loïc Huertas</a>
   */
 case class Container(id: String, name: String = "unknown") extends Target {
-  override def toString: String = id
+  override def toString: String = name.substring(1)
 }
 
 /**

--- a/powerapi-core/src/main/scala/org/powerapi/module/cpu/simple/CpuSimpleModule.scala
+++ b/powerapi-core/src/main/scala/org/powerapi/module/cpu/simple/CpuSimpleModule.scala
@@ -34,7 +34,6 @@ class CpuSimpleModule(osHelper: OSHelper, tdp: Double, tdpFactor: Double) extend
 object ProcFSCpuSimpleModule extends CpuSimpleFormulaConfiguration {
   def apply(): CpuSimpleModule = {
     val linuxHelper = new LinuxHelper
-
     new CpuSimpleModule(linuxHelper, tdp, tdpFactor)
   }
 }
@@ -47,7 +46,6 @@ object SigarCpuSimpleModule extends CpuSimpleFormulaConfiguration with SigarHelp
 
   def apply(): CpuSimpleModule = {
     val sigarHelper = new SigarHelper(sigar)
-
     new CpuSimpleModule(sigarHelper, tdp, tdpFactor)
   }
 }


### PR DESCRIPTION
The containers can now be monitored using theirs Name, short and full ID.
Use of the container's name as target name instead of the full ID.
Trying to monitor an unknown container is considered as fatal error and PowerAPI will shutdown.

Fix #90 