### PR TITLE
Docker images improvement

### DIFF
--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY powerapi-cli/target/universal/stage /powerapi-cli
+COPY powerapi-cli/target/universal/stage /powerapi
 
-WORKDIR /powerapi-cli
+WORKDIR /powerapi
 
-ENTRYPOINT ["/powerapi-cli/bin/powerapi"]
+ENTRYPOINT ["/powerapi/bin/powerapi"]

--- a/docker/sampling/Dockerfile
+++ b/docker/sampling/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY powerapi-sampling-cpu/target/universal/stage /powerapi-sampling-cpu
+COPY powerapi-sampling-cpu/target/universal/stage /powerapi
 
-WORKDIR /powerapi-sampling-cpu
+WORKDIR /powerapi
 
-ENTRYPOINT ["/powerapi-sampling-cpu/bin/sampling-cpu"]
+ENTRYPOINT ["/powerapi/bin/sampling-cpu"]
 CMD ["--all", "results/sampling", "results/processing", "results/computing"]


### PR DESCRIPTION
PR overview:

- Use the `/powerapi` working directory for both images ;
- Update Docker README with recent images usage and more examples.